### PR TITLE
Use old base image for aarch64

### DIFF
--- a/hassiogooglebackup/build.json
+++ b/hassiogooglebackup/build.json
@@ -1,0 +1,5 @@
+{
+    "build_from": {
+        "aarch64": "homeassistant/aarch64-base:3.8"
+    }
+}


### PR DESCRIPTION
The latest image is based on Alpine 3.9, which has issues with python3
segfaulting.

This fixes #8 

A better long-term fix is probably to switch to using `homeassistant/{arch}-base-python` for all platforms, since it apparently has a working python3 pre-installed (it doesn't use the version from the alpine repos), but that's a bit more work (the `Dockerfile` in this project would need some changes).